### PR TITLE
fixed a bug  in flannel-install.service unit.

### DIFF
--- a/cloud-init/leader-flannel.yaml
+++ b/cloud-init/leader-flannel.yaml
@@ -151,8 +151,8 @@ coreos:
               Environment=FLANNEL_VERSION='0.3.0'
               ExecStart=-/bin/mkdir -p /opt/bin
               ExecStart=/bin/bash -c "[[ -x /opt/bin/flanneld ]] || \
-                  (cd /tmp; curl -L ${FLANNEL_RELEASE_URL} | tar -xz) &&  \
-                  install /tmp/flannel-${FLANNEL_VERSION}/flanneld /opt/bin"
+                  (cd /tmp; curl -L ${FLANNEL_RELEASE_URL} | tar -xz &&  \
+                  install /tmp/flannel-${FLANNEL_VERSION}/flanneld /opt/bin)"
         - name: flannel.service
           command: start
           content: |            


### PR DESCRIPTION
moved flanneld installation command  in the same subshell as that of the binary download.